### PR TITLE
fix: support drydock data envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ enable_skip: true
 update_interval: 30000
 wud_api:
   url: http://your-wud-instance:3000
+  api_path: /api/v1                    # Optional; auto-detects /api/v1 then /api when omitted
   show_update_buttons: true
   auth: your_bearer_token_here         # Bearer token (takes priority)
   user: your_username                  # Basic auth (used if auth is not set)
@@ -106,6 +107,7 @@ custom_icons:
 | `enable_skip`                 | boolean         | `false`                                    | Show a Skip button on each pending update (see below)              |
 | `update_interval`             | number          | `30000`                                    | Interval in ms to refresh WUD API data                             |
 | `wud_api.url`                 | string          | —                                          | URL of your WUD instance                                           |
+| `wud_api.api_path`            | string          | Auto (`/api/v1`, then `/api`)              | API base path override (`/api` for legacy WUD servers)             |
 | `wud_api.show_update_buttons` | boolean         | `true`                                     | Show update trigger buttons                                        |
 | `wud_api.auth`                | string          | —                                          | Bearer token for WUD API authentication                            |
 | `wud_api.user`                | string          | —                                          | Username for WUD Basic authentication                              |

--- a/wud-card.js
+++ b/wud-card.js
@@ -105,6 +105,7 @@ class WudCard extends HTMLElement {
         user: config.wud_api.user || null,
         password: config.wud_api.password || null,
         show_update_buttons: config.wud_api.show_update_buttons !== false,
+        api_path: config.wud_api.api_path || null,
         trigger_filter: config.wud_api.trigger_filter || 'all'
       } : null,
       release_notes: config.release_notes || {},
@@ -251,7 +252,7 @@ class WudCard extends HTMLElement {
     if (!this.config.wud_api?.url || !this.config.wud_api?.show_update_buttons) return;
 
     try {
-      const containers = this._unwrapCollection(await this.fetchApi('/api/containers'));
+      const containers = this._unwrapCollection(await this.fetchApi('/containers'));
       this.wudReachable = true;
       this.wudContainers.clear();
       this.containerTriggers.clear();
@@ -260,7 +261,7 @@ class WudCard extends HTMLElement {
       await Promise.all(containers.map(async (c) => {
         try {
           const triggers = this._unwrapCollection(
-            await this.fetchApi(`/api/containers/${encodeURIComponent(c.id)}/triggers`)
+            await this.fetchApi(`/containers/${encodeURIComponent(c.id)}/triggers`)
           );
           this.containerTriggers.set(c.id, triggers);
         } catch (e) {
@@ -297,22 +298,43 @@ class WudCard extends HTMLElement {
       throw new Error('WUD API URL not configured');
     }
 
-    const response = await fetch(`${this.config.wud_api.url}${path}`, {
-      headers: this._getAuthHeaders()
-    });
-
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const response = await this._fetchApiResponse(path);
     return response.json();
+  }
+
+  _getApiPaths() {
+    const configuredPath = this.config.wud_api?.api_path;
+    if (configuredPath) {
+      const normalized = configuredPath.startsWith('/')
+        ? configuredPath.replace(/\/$/, '')
+        : `/${configuredPath.replace(/\/$/, '')}`;
+      return [normalized];
+    }
+    return ['/api/v1', '/api'];
+  }
+
+  async _fetchApiResponse(path, options = {}) {
+    let lastResponse = null;
+    const headers = { ...this._getAuthHeaders(), ...(options.headers || {}) };
+
+    for (const apiPath of this._getApiPaths()) {
+      const response = await fetch(`${this.config.wud_api.url}${apiPath}${path}`, {
+        ...options,
+        headers
+      });
+      if (response.ok) return response;
+      lastResponse = response;
+      if (this.config.wud_api?.api_path || response.status !== 404) break;
+    }
+
+    throw new Error(`HTTP ${lastResponse?.status || 'unknown'}`);
   }
 
   async checkForUpdates() {
     try {
       this.showNotification(this.t('checking_updates'), 'info');
 
-      const response = await fetch(`${this.config.wud_api.url}/api/containers/watch`, {
-        method: 'POST',
-        headers: this._getAuthHeaders()
-      });
+      const response = await this._fetchApiResponse('/containers/watch', { method: 'POST' });
 
       if (response.ok) {
         this.showNotification(this.t('check_started'), 'success');
@@ -507,17 +529,14 @@ class WudCard extends HTMLElement {
       this.showNotification(`${this.t('update_started')} ${name}...`, 'info');
 
       const triggerPath = [
-        '/api/containers',
+        '/containers',
         encodeURIComponent(containerId),
         'triggers',
         encodeURIComponent(trigger.type),
         encodeURIComponent(trigger.name),
         ...(trigger.agent ? [encodeURIComponent(trigger.agent)] : []),
       ].join('/');
-      const response = await fetch(`${this.config.wud_api.url}${triggerPath}`, {
-        method: 'POST',
-        headers: this._getAuthHeaders()
-      });
+      const response = await this._fetchApiResponse(triggerPath, { method: 'POST' });
 
       if (response.ok) {
         this.showNotification(`${this.t('update_triggered')} ${name}`, 'success');

--- a/wud-card.js
+++ b/wud-card.js
@@ -251,16 +251,17 @@ class WudCard extends HTMLElement {
     if (!this.config.wud_api?.url || !this.config.wud_api?.show_update_buttons) return;
 
     try {
-      const containersResponse = await this.fetchApi('/api/containers');
-      const containers = Array.isArray(containersResponse) ? containersResponse : containersResponse.data;
+      const containers = this._unwrapCollection(await this.fetchApi('/api/containers'));
       this.wudReachable = true;
       this.wudContainers.clear();
+      this.containerTriggers.clear();
       containers.forEach(c => this.wudContainers.set(c.id, c));
 
       await Promise.all(containers.map(async (c) => {
         try {
-          const triggersResponse = await this.fetchApi(`/api/containers/${encodeURIComponent(c.id)}/triggers`);
-          const triggers = Array.isArray(triggersResponse) ? triggersResponse : triggersResponse.data;
+          const triggers = this._unwrapCollection(
+            await this.fetchApi(`/api/containers/${encodeURIComponent(c.id)}/triggers`)
+          );
           this.containerTriggers.set(c.id, triggers);
         } catch (e) {
           console.warn(`Failed to load triggers for ${c.id}:`, e);
@@ -270,6 +271,12 @@ class WudCard extends HTMLElement {
       this.wudReachable = false;
       console.warn('WUD API not reachable:', e);
     }
+  }
+
+  _unwrapCollection(response) {
+    if (Array.isArray(response)) return response;
+    if (Array.isArray(response?.data)) return response.data;
+    return [];
   }
 
   _getAuthHeaders() {
@@ -332,6 +339,12 @@ class WudCard extends HTMLElement {
   _findWudContainer(entityId) {
     if (!this.wudContainers.size) return null;
 
+    if (entityId.startsWith('wud_api.')) {
+      const id = decodeURIComponent(entityId.slice('wud_api.'.length));
+      const container = this.wudContainers.get(id);
+      if (container) return { id, container };
+    }
+
     const haState = this._hass?.states[entityId];
     const haFriendlyName = haState?.attributes?.friendly_name || '';
     const haDisplayName = haState?.attributes?.display_name || '';
@@ -344,13 +357,35 @@ class WudCard extends HTMLElement {
     );
 
     for (const [id, container] of this.wudContainers) {
-      const wudName = normalize(container.displayName || container.name || '');
-      if (wudName && candidates.has(wudName)) {
+      const wudCandidates = this._getContainerMatchCandidates(container).map(normalize).filter(Boolean);
+      if (wudCandidates.some(candidate => candidates.has(candidate))) {
         return { id, container };
       }
     }
 
     return null;
+  }
+
+  _getContainerMatchCandidates(container) {
+    const values = [
+      container.id,
+      container.name,
+      container.displayName,
+      container.identityKey,
+      container.image?.name,
+      container.labels?.['com.docker.compose.service'],
+      container.labels?.['org.opencontainers.image.title'],
+    ];
+
+    if (container.identityKey) {
+      values.push(...container.identityKey.split('::'));
+    }
+
+    if (container.image?.name) {
+      values.push(container.image.name.split('/').pop());
+    }
+
+    return values.filter(Boolean);
   }
 
   // Strip well-known HA entity ID prefixes to get the bare container name portion.
@@ -377,6 +412,11 @@ class WudCard extends HTMLElement {
   //   2. WUD API container displayName / name
   //   3. Last resort: humanise the entity ID tail
   getContainerName(entityId) {
+    if (entityId.startsWith('wud_api.')) {
+      const found = this._findWudContainer(entityId);
+      if (found) return found.container.displayName || found.container.name || found.id;
+    }
+
     const haState = this._hass?.states[entityId];
 
     // 1. Use HA's friendly_name, but strip the integration prefix HA adds automatically.
@@ -466,13 +506,18 @@ class WudCard extends HTMLElement {
       const name = this.getContainerName(entityId);
       this.showNotification(`${this.t('update_started')} ${name}...`, 'info');
 
-      const response = await fetch(
-        `${this.config.wud_api.url}/api/containers/${encodeURIComponent(containerId)}/triggers/${encodeURIComponent(trigger.type)}/${encodeURIComponent(trigger.name)}`,
-        {
-          method: 'POST',
-          headers: this._getAuthHeaders()
-        }
-      );
+      const triggerPath = [
+        '/api/containers',
+        encodeURIComponent(containerId),
+        'triggers',
+        encodeURIComponent(trigger.type),
+        encodeURIComponent(trigger.name),
+        ...(trigger.agent ? [encodeURIComponent(trigger.agent)] : []),
+      ].join('/');
+      const response = await fetch(`${this.config.wud_api.url}${triggerPath}`, {
+        method: 'POST',
+        headers: this._getAuthHeaders()
+      });
 
       if (response.ok) {
         this.showNotification(`${this.t('update_triggered')} ${name}`, 'success');
@@ -581,10 +626,28 @@ class WudCard extends HTMLElement {
     return `<button class="btn" disabled>${this.t('no_trigger')}</button>`;
   }
 
+  _getApiContainerEntities() {
+    return [...this.wudContainers.entries()].map(([id, container]) => ({
+      entityId: `wud_api.${encodeURIComponent(id)}`,
+      state: {
+        state: container.updateAvailable ? 'on' : 'off',
+        attributes: {
+          friendly_name: container.displayName || container.name || id,
+          installed_version: container.image?.tag?.value || '',
+          latest_version: container.result?.tag || container.result?.suggestedTag || ''
+        }
+      },
+      name: container.displayName || container.name || id,
+      icon: this.getContainerIcon(container.displayName || container.name || id),
+      triggers: this.containerTriggers.get(id) || [],
+      isUpdating: this.updatingContainers.has(`wud_api.${encodeURIComponent(id)}`)
+    }));
+  }
+
   render() {
     if (!this._hass) return;
 
-    const entities = Object.keys(this._hass.states)
+    const hassEntities = Object.keys(this._hass.states)
       .filter(id => id.startsWith('update.') && this.matchesFilter(id))
       .map(id => ({
         entityId: id,
@@ -595,6 +658,7 @@ class WudCard extends HTMLElement {
         isUpdating: this.updatingContainers.has(id)
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
+    const entities = hassEntities.length ? hassEntities : this._getApiContainerEntities();
 
     const allUpdates = entities.filter(e => e.state.state === 'on');
     const skipped = this.config.enable_skip

--- a/wud-card.js
+++ b/wud-card.js
@@ -251,14 +251,16 @@ class WudCard extends HTMLElement {
     if (!this.config.wud_api?.url || !this.config.wud_api?.show_update_buttons) return;
 
     try {
-      const containers = await this.fetchApi('/api/containers');
+      const containersResponse = await this.fetchApi('/api/containers');
+      const containers = Array.isArray(containersResponse) ? containersResponse : containersResponse.data;
       this.wudReachable = true;
       this.wudContainers.clear();
       containers.forEach(c => this.wudContainers.set(c.id, c));
 
       await Promise.all(containers.map(async (c) => {
         try {
-          const triggers = await this.fetchApi(`/api/containers/${encodeURIComponent(c.id)}/triggers`);
+          const triggersResponse = await this.fetchApi(`/api/containers/${encodeURIComponent(c.id)}/triggers`);
+          const triggers = Array.isArray(triggersResponse) ? triggersResponse : triggersResponse.data;
           this.containerTriggers.set(c.id, triggers);
         } catch (e) {
           console.warn(`Failed to load triggers for ${c.id}:`, e);


### PR DESCRIPTION
## Summary

- Support Drydock v1.4.0+ collection responses that wrap arrays in `{ data, total }`.

- Keep existing WUD bare-array responses working.
## Validation
- `node --check wud-card.js`





